### PR TITLE
Add connects_query configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Some settings are configurable through app config vars at runtime. Refer to the 
 - `PGBOUNCER_SERVER_RESET_QUERY` Default is empty when pool mode is transaction, and "DISCARD ALL;" when session.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`
 - `PGBOUNCER_QUERY_WAIT_TIMEOUT` Default is 120 seconds, helps when the server is down or the database rejects connections for any reason. If this is disabled, clients will be queued infinitely.
+- `PGBOUNCER_CONNECT_QUERY` Query to be executed after a connection is established, but before allowing the connection to be used by any clients. If the query raises errors, they are logged but ignored otherwise.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -89,8 +89,13 @@ do
 "$DB_USER" "$DB_MD5_PASS"
 EOFEOF
 
-  cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF
-$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT
+  CONNECT_QUERY_PARAM=''
+  if [[ "$PGBOUNCER_CONNECT_QUERY" ]]; then
+    CONNECT_QUERY_PARAM="connect_query='${PGBOUNCER_CONNECT_QUERY//\'/\'\'}'"
+  fi
+
+  cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
+$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT $CONNECT_QUERY_PARAM
 EOFEOF
 
   (( n += 1 ))


### PR DESCRIPTION
This commit adds the `connect_query` configuration option using a `PGBOUNCER_CONNECT_QUERY` environment variable.